### PR TITLE
Added performance enhancements to reduce CPU Load of video streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 **/.DS_Store
 .login
 logins
+.vscode/

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ streamer = Streamer(port, require_login, login_file=login_file, login_key=login_
 video_capture = cv2.VideoCapture(0)
 
 while True:
-    _, frame = cap.read()
+    _, frame = video_capture.read()
 
     streamer.update_frame(frame)
 
     if not streamer.is_streaming:
         streamer.start_streaming()
 
-    cv2.waitKey(1)
+    cv2.waitKey(30)
 ```
 
 **If there is no logins file or key found at the path given, it will create one for you**. Logins will be stored in a `.txt` file `logins.txt` but will be **encrypted**. Therefore, unless someone has the key (in this example, `loginkey.txt`) the `logins.txt` file will be able to show logins or passwords. It is very unsafe to keep the login key somewhere publicly accessible; it's suggested you hide it well and do not upload it anywhere.


### PR DESCRIPTION
Added delays to both client and server side of code to ensure that approximately 30fps is being captured. 
Because we're using mjpeg streams, the network cameras will happily dump their buffer every you ask them to, leading to over saturation of network resources.

Moved the jpeg generation so that it only happens once per frame, preventing repeated encoding of the same frame.

Added parameter for jpeg quality, lower quality typically requires additional processing, and obviously we don't want quality too low, most web things tend toward 70%, but that's generally given a much more sophisticated encoding process than what opencv is offering, this parameter may need to be tweaked to get optimal performance.